### PR TITLE
Add lazyslurm TUI to Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ High Performance Computing tools and resources for engineers and administrators.
 - [Lustre Exporter](https://github.com/GSI-HPC/lustre_exporter) - Prometheus exporter for use with the Lustre parallel filesystem `GPL-3.0`.
 - [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) - NVIDIA GPU metrics exporter for Prometheus leveraging DCGM `Apache-2.0`.
 
+### Terminal
+- [lazyslurm](https://github.com/hill/lazyslurm) - A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions `MIT`.
+
 ## Journals
 - [Journal of Super Computing](https://www.springer.com/journal/11227) - An International Journal of High-Performance Computer Design, Analysis, and Use.
 


### PR DESCRIPTION
Adds lazyslurm under a new Terminal subsection in Monitoring.

A lazygit-style terminal UI for the Slurm workload manager, built with ratatui. It monitors jobs, tails logs, and shows node and partition state from a single binary. MIT licensed, published on crates.io.

The entry is added to the bottom of the category with a license tag.

![lazyslurm demo](https://github.com/hill/lazyslurm/raw/master/media/demo.gif)
